### PR TITLE
Forward text ref for pseudo class effect hooks

### DIFF
--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 import { LinkProps } from './types'
-import { TouchableOpacity, Text, TextStyle } from 'react-native'
+import { TouchableOpacity, Text } from 'react-native'
 import useRouting from '../../hooks/use-routing'
 import empty from '../../utils/empty'
 
@@ -29,7 +29,7 @@ import empty from '../../utils/empty'
  *```
  *
  */
-export default function Link(props: LinkProps) {
+const Link = React.forwardRef((props: LinkProps, ref) => {
   const { navigate } = useRouting()
   const {
     children,
@@ -42,9 +42,11 @@ export default function Link(props: LinkProps) {
 
   return (
     <TouchableOpacity {...touchableOpacityProps} onPress={nav}>
-      <Text style={style} accessibilityRole="link">
+      <Text ref={ref} style={style} accessibilityRole="link">
         {children}
       </Text>
     </TouchableOpacity>
   )
-}
+})
+
+export default Link;

--- a/src/components/Link/index.web.tsx
+++ b/src/components/Link/index.web.tsx
@@ -29,7 +29,7 @@ import { LinkProps } from './types'
  *```
  *
  */
-export default function Link(props: LinkProps) {
+const Link = React.forwardRef((props: LinkProps, ref) => {
   const {
     nextLinkProps = empty.object,
     style = empty.object,
@@ -51,6 +51,7 @@ export default function Link(props: LinkProps) {
   return (
     <NextLink passHref {...nextLinkProps} href={href} as={props.web?.as}>
       <Text
+        ref={ref}
         accessibilityRole="link"
         style={style}
       >
@@ -58,4 +59,6 @@ export default function Link(props: LinkProps) {
       </Text>
     </NextLink>
   )
-}
+})
+
+export default Link;


### PR DESCRIPTION
Make the following block possible by forwarding the ref to the `<Text />` element.

```tsx
import { Link } from 'expo-next-react-navigation';
import React from 'react';
import { StyleSheet, Text } from 'react-native';
import { useHover, useActive } from 'react-native-web-hooks';

export default function CustomLink({ routeName, style, ...props }) {

  const ref = React.useRef(null)
  const { isHovered } = useHover(ref)
  const { isActive } = useActive(ref)

  const responsiveStyle = StyleSheet.flatten([
    style, 
    isHovered && { opacity: 0.6 }, 
    isActive && { color: 'blue' }
  ])

  return <Link {...props} ref={ref} routeName={routeName} style={responsiveStyle} />
}
```