### PR TITLE
Check if router is not null (null at the first server-side rendering)

### DIFF
--- a/src/hooks/use-routing/index.web.ts
+++ b/src/hooks/use-routing/index.web.ts
@@ -7,13 +7,17 @@ import empty from '../../utils/empty'
 const goBack = () => Router.back()
 
 export default function useRouting() {
-  const { query } = useRouter()
+  const router = useRouter()
 
   const getParam = <Param>(
     param: Parameters<typeof _.get>['1'],
     fallback?: unknown
-  ): Param => {
-    const val: Param = _.get(query, param) ?? fallback
+  ): Param | undefined => {
+    if (!router) {
+      return undefined
+    }
+
+    const val: Param = _.get(router.query, param) ?? fallback
     if (val === undefined) {
       console.warn('Tried to get param', param, 'but it does not exist')
     }


### PR DESCRIPTION
I am experiencing the same problem than reported in the issue #10 using both Next `9.1.5` and `9.2.2`. The `useRouter` returns `null` at the first server-side rendering.

This PR is a quick tentative to fix the problem.
Depends on PR #9 